### PR TITLE
Add I18n support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,26 @@
 sudo: false
 branches:
   only:
-    - release
+    - i18n
 
 language: node_js
 node_js:
   - 'lts/carbon'
 script: true
+before_install:
+  - sudo apt-get install ruby
+  - gem install bundler
+install:
+  - node --version
+  - npm --version
+  - nvm --version
+  - yarn --version
+  - gem --version
+  - bundle --version
+  - bundle install
+  - bundle exec jekyll build
+  - yarn
+  - yarn run build
 after_success:
   - git config user.name 'TravisCI Auto-publisher'
   - git config user.email 'travis-auto-publish@example.com'
@@ -14,9 +28,11 @@ after_success:
       printf '#!/bin/sh -e\necho %s' "$GH_PUBLISH_TOKEN" > gh-publish-pass.sh &&
       chmod u+x gh-publish-pass.sh &&
       yarn run build &&
-      rm index.css index.js .travis.yml .vimrc package.json yarn.lock &&
-      rm -r assets/css/ assets/js/ &&
-      git add -f bundle.js bundle.css index.css index.js .travis.yml .vimrc package.json yarn.lock assets/css assets/js &&
-      git commit -m 'Auto-publishing via TravisCI [skip ci]' &&
+      GLOBIGNORE='.git:_site' &&
+      rm -r * &&
+      mv _site/* ./ &&
+      rm -r _site/ &&
+      git add . &&
+      git commit -m 'Auto-publishing via TravisCI' &&
       GIT_ASKPASS=./gh-publish-pass.sh git push origin +HEAD:refs/heads/master;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,31 +8,25 @@ node_js:
   - 'lts/carbon'
 script: true
 before_install:
-  - sudo apt-get install ruby
   - gem install bundler
-install:
-  - node --version
-  - npm --version
-  - nvm --version
-  - yarn --version
   - gem --version
-  - bundle --version
   - bundle install
-  - bundle exec jekyll build
+  - bundle --version
   - yarn
+install:
   - yarn run build
+  - bundle exec jekyll build
 after_success:
   - git config user.name 'TravisCI Auto-publisher'
   - git config user.email 'travis-auto-publish@example.com'
   - if [ "$TRAVIS_PULL_REQUEST" = false ]; then
-      printf '#!/bin/sh -e\necho %s' "$GH_PUBLISH_TOKEN" > gh-publish-pass.sh &&
-      chmod u+x gh-publish-pass.sh &&
-      yarn run build &&
       GLOBIGNORE='.git:_site' &&
       rm -r * &&
       mv _site/* ./ &&
       rm -r _site/ &&
       git add . &&
+      printf '#!/bin/sh -e\necho %s' "$GH_PUBLISH_TOKEN" > gh-publish-pass.sh &&
+      chmod u+x gh-publish-pass.sh &&
       git commit -m 'Auto-publishing via TravisCI' &&
       GIT_ASKPASS=./gh-publish-pass.sh git push origin +HEAD:refs/heads/master;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 sudo: false
 branches:
   only:
-    - i18n
+    - release
 
 language: node_js
 node_js:
   - 'lts/carbon'
 script: true
 before_install:
-  - gem install bundler
   - gem --version
-  - bundle install
+  - gem install bundler
   - bundle --version
+  - bundle install
   - yarn
 install:
   - yarn run build

--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ plugins:
 
 # Jekyll Multiple Languages Plugin
 languages: ["en", "ja"]
-exclude_from_localizations: ["javascript", "images", "css"]
+exclude_from_localizations: ["assets", "projects", "bundle.js", "bundle.css"]
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -9,7 +9,7 @@
     {% endif %}
 
     <link rel="shortcut icon" type="image/png" href="{{ 'favicon.png' | prepend: site.baseurl_root }}"/>
-    <link rel="stylesheet" href="{{ 'bundle.css' | prepend: site.baseurl_root }}" media="screen">
+    <link rel="stylesheet" href="{{ '/bundle.css' | prepend: site.baseurl_root }}" media="screen">
 
     <title>{{ page.title }} - Mateus Etto Website</title>
   </head>
@@ -53,6 +53,6 @@
       <div class="footer">
       </div>
     </div>
-    <script type="text/javascript" src="{{ 'bundle.js' | prepend: site.baseurl_root }}"></script>
+    <script type="text/javascript" src="{{ '/bundle.js' | prepend: site.baseurl_root }}"></script>
   </body>
 </html>

--- a/resume.html
+++ b/resume.html
@@ -8,7 +8,7 @@ permalink: /resume
 <div class="resume">
   <div class="personal-card">
     <div class="photo">
-      <img src="{{ 'assets/img/profile_photo.jpg' | prepend: site.baseurl_root }}" alt="Profile Photo">
+      <img src="{{ '/assets/img/profile_photo.jpg' | prepend: site.baseurl_root }}" alt="Profile Photo">
     </div>
     <div class="basic-info">
       <div class="name"><h1><b>{% t resume.name %}</b></h1></div>
@@ -31,7 +31,7 @@ permalink: /resume
         <h1><b>{% t resume.education %}</b></h1>
         <div class="resume-card">
           <div class="card-logo university">
-            <img src="{{ 'assets/img/logo_unesp.png' | prepend: site.baseurl_root }}" alt="Card Logo">
+            <img src="{{ '/assets/img/logo_unesp.png' | prepend: site.baseurl_root }}" alt="Card Logo">
           </div>
           <div class="card-details">
             <h3>Sao Paulo State University</h3>
@@ -42,7 +42,7 @@ permalink: /resume
         </div>
         <div class="resume-card">
           <div class="card-logo university">
-            <img src="{{ 'assets/img/logo_waseda.png' | prepend: site.baseurl_root }}" alt="Card Logo">
+            <img src="{{ '/assets/img/logo_waseda.png' | prepend: site.baseurl_root }}" alt="Card Logo">
           </div>
           <div class="card-details">
             <h3>Waseda University (Study abroad)</h3>
@@ -57,7 +57,7 @@ permalink: /resume
         <h1><b>{% t resume.work_experience %}</b></h1>
         <div class="resume-card">
           <div class="card-logo">
-            <img src="{{ 'assets/img/logo_cograph.png' | prepend: site.baseurl_root }}" alt="Card Logo">
+            <img src="{{ '/assets/img/logo_cograph.png' | prepend: site.baseurl_root }}" alt="Card Logo">
           </div>
           <div class="card-details">
             <h3>Co-graph</h3>
@@ -67,7 +67,7 @@ permalink: /resume
         </div>
         <div class="resume-card">
           <div class="card-logo">
-            <img src="{{ 'assets/img/logo_voxus.svg' | prepend: site.baseurl_root }}" alt="Card Logo">
+            <img src="{{ '/assets/img/logo_voxus.svg' | prepend: site.baseurl_root }}" alt="Card Logo">
           </div>
           <div class="card-details">
             <h3>Voxus</h3>
@@ -77,7 +77,7 @@ permalink: /resume
         </div>
         <div class="resume-card">
           <div class="card-logo">
-            <img src="{{ 'assets/img/logo_ltia.png' | prepend: site.baseurl_root }}" alt="Card Logo">
+            <img src="{{ '/assets/img/logo_ltia.png' | prepend: site.baseurl_root }}" alt="Card Logo">
           </div>
           <div class="card-details">
             <h3>Laboratory of Applied Information Technology</h3>


### PR DESCRIPTION
Retry for PR #21 , that was reverted because GitHub does not support the [Jekyll Multiple Languages Plugin](https://github.com/Anthony-Gaudino/jekyll-multiple-languages-plugin) in PR #22 .

Now the site is built in TravisCI and `_site` folder published.